### PR TITLE
Close unable to generate migration with rails g

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" from the root of your extension
+
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/spree_sale_prices/engine', __FILE__)
+
+require 'rails/all'
+require 'rails/engine/commands'


### PR DESCRIPTION
can not run rails generate a migration to extend the gem functionality in Spree 4.1.0.